### PR TITLE
add some retry when making requests to stats/summary

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/alecthomas/kong v0.7.1
+	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/google/go-cmp v0.5.9
 	github.com/oklog/run v1.1.0
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/cenkalti/backoff/v4 v4.2.0 h1:HN5dHm3WBOgndBH6E8V0q2jIYIR3s9yglV8k/+MN3u4=
+github.com/cenkalti/backoff/v4 v4.2.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
### What/Why

We took some time to update to 0.6 and after we did started getting more errors of the form:

Timeout:
```
Get "https://ip-172-20-74-225.aws.dev.prdt.biz:10250/stats/summary": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
--

github.com/salesforce/kubelet-summary-exporter/pkg/scraper.(*Scraper).Collect
	/go/pkg/mod/github.com/salesforce/kubelet-summary-exporter@v0.0.6/pkg/scraper/scraper.go:65
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/registry.go:456
```

Connection refused:
```
error | Get "https://ip-172-20-35-68.aws.dev.prdt.biz:10250/stats/summary": dial tcp 172.20.35.68:10250: connect: connection refused
--

github.com/salesforce/kubelet-summary-exporter/pkg/scraper.(*Scraper).Collect 	/go/pkg/mod/github.com/salesforce/kubelet-summary-exporter@v0.0.6/pkg/scraper/scraper.go:65 
github.com/prometheus/client_golang/prometheus.(*Registry).Gather.func1 	/go/pkg/mod/github.com/prometheus/client_golang@v1.14.0/prometheus/registry.go:456
```
Turns out this semi late edition to logging wasn't present in previous versions: https://github.com/salesforce/kubelet-summary-exporter/commit/a204104aae4d56deec73efe62af41d3af43598f5#diff-f291d33f14f41a372840977811a269a3ed393282244d814ebb408d6f73a39270R65

I'd still like to know if these errors happen all the time (and we aren't getting metrics), but am ok with just retrying after a little wait a few times.